### PR TITLE
Divyanshu | Add in widget -  Powered by 36Blocks

### DIFF
--- a/apps/36-blocks-widget/src/app/otp/widget/widget.component.ts
+++ b/apps/36-blocks-widget/src/app/otp/widget/widget.component.ts
@@ -55,6 +55,26 @@ import { SubscriptionCenterComponent } from '../component/subscription-center/su
 import { environment } from 'apps/36-blocks-widget/src/environments/environment';
 import { InputFields, WidgetVersion } from './utility/model';
 import { WidgetPortalRef, WidgetPortalService } from '../service/widget-portal.service';
+
+const THEME_COLORS = {
+    dark: {
+        buttonText: '#ffffff',
+        buttonBorder: '1px solid #ffffff',
+        buttonBorderIconOnly: '1px solid #ffffff',
+        poweredByLabel: '#9ca3af',
+        logoText: '#F8F8F8',
+        primaryColorFallback: '#FFFFFF',
+    },
+    light: {
+        buttonText: '#111827',
+        buttonBorder: '1px solid #000000',
+        buttonBorderIconOnly: '1px solid #d1d5db',
+        poweredByLabel: '#6b7280',
+        logoText: '#1a1a1a',
+        primaryColorFallback: '#000000',
+    },
+} as const;
+
 @Component({
     selector: 'proxy-auth-widget',
     imports: [
@@ -642,11 +662,12 @@ export class ProxyAuthWidgetComponent extends BaseComponent implements OnInit, O
     }): string {
         const isDark = this.themeService.isDark();
         if (this.version !== WidgetVersion.V2) {
-            return isDark ? '#FFFFFF' : '#000000';
+            return isDark ? THEME_COLORS.dark.primaryColorFallback : THEME_COLORS.light.primaryColorFallback;
         }
+        const colors = isDark ? THEME_COLORS.dark : THEME_COLORS.light;
         return isDark
-            ? uiPreferences?.dark_theme_primary_color ?? '#FFFFFF'
-            : uiPreferences?.light_theme_primary_color ?? '#000000';
+            ? (uiPreferences?.dark_theme_primary_color ?? colors.primaryColorFallback)
+            : (uiPreferences?.light_theme_primary_color ?? colors.primaryColorFallback);
     }
 
     public appendPasswordAuthenticationButtonV2(element: HTMLElement, buttonsData: any, totalButtons: number): void {
@@ -1745,6 +1766,36 @@ export class ProxyAuthWidgetComponent extends BaseComponent implements OnInit, O
         // Append elements
         this.renderer.appendChild(paragraph, link);
         this.renderer.appendChild(element, paragraph);
+
+        // Powered by footer
+        const poweredBy: HTMLParagraphElement = this.renderer.createElement('p');
+        poweredBy.setAttribute('data-powered-by', 'true');
+        poweredBy.style.cssText = `
+            margin: 12px 8px 12px 8px !important;
+            font-size: 11px !important;
+            font-family: inherit !important;
+            line-height: 1 !important;
+            display: flex !important;
+            align-items: center !important;
+            justify-content: center !important;
+            gap: 4px !important;
+            color: ${this.themeService.isDark() ? THEME_COLORS.dark.poweredByLabel : THEME_COLORS.light.poweredByLabel} !important;
+            width: ${this.version === 'v1' ? '260px' : '316px'} !important;
+        `;
+
+        const poweredByText = this.renderer.createText('Powered by');
+        const logoSpan: HTMLSpanElement = this.renderer.createElement('span');
+        logoSpan.style.cssText = `
+            display: inline-flex !important;
+            align-items: center !important;
+            height: 14px !important;
+        `;
+        const logoTextColor = this.themeService.isDark() ? THEME_COLORS.dark.logoText : THEME_COLORS.light.logoText;
+        logoSpan.innerHTML = `<svg width="262" height="48" viewBox="0 0 262 48" fill="none" xmlns="http://www.w3.org/2000/svg" style="height:14px;width:auto;display:block;"><path fill-rule="evenodd" clip-rule="evenodd" d="M0.450714 22.9193L23.0465 0.448227C23.6475 -0.149409 24.6215 -0.149409 25.2224 0.448227L30 5.19941L34.7775 0.448227C35.3785 -0.149409 36.3525 -0.149409 36.9535 0.448227L59.5493 22.9193C60.1502 23.517 60.1502 24.4856 59.5493 25.0832L36.9535 47.5518C36.3525 48.1494 35.3785 48.1494 34.7775 47.5518L30 42.8006L25.2224 47.5518C24.6215 48.1494 23.6475 48.1494 23.0465 47.5518L0.450714 25.0807C-0.150238 24.4855 -0.150238 23.5145 0.450714 22.9193ZM32.1759 7.36358L47.8179 22.9193C48.4189 23.517 48.4189 24.4856 47.8179 25.0832L32.1759 40.639L35.8667 44.3094L56.2863 24.0026L35.8667 3.69318L32.1759 7.36358ZM12.1819 22.9193L27.824 7.36358L24.1332 3.69312L3.71361 24L24.1332 44.3068L27.824 40.6363L12.1819 25.0806C11.581 24.4855 11.581 23.5145 12.1819 22.9193ZM30.0003 9.52463L15.4447 23.9998L30.0003 38.475L44.5558 23.9998L30.0003 9.52463Z" fill="#5DD62C"/><path d="M88.868 39.94C86.8733 39.94 85.0547 39.5733 83.412 38.84C81.7987 38.0773 80.4347 36.9773 79.32 35.54L82.136 32.724C82.8107 33.7507 83.7347 34.572 84.908 35.188C86.0813 35.7747 87.3867 36.068 88.824 36.068C90.1733 36.068 91.332 35.8187 92.3 35.32C93.2973 34.792 94.0747 34.0587 94.632 33.12C95.2187 32.1813 95.512 31.096 95.512 29.864C95.512 28.6027 95.2187 27.5173 94.632 26.608C94.0747 25.6693 93.2827 24.9507 92.256 24.452C91.2293 23.9533 90.012 23.704 88.604 23.704C88.076 23.704 87.548 23.748 87.02 23.836C86.492 23.8947 85.9787 23.9973 85.48 24.144L87.24 21.768C87.7973 21.504 88.3987 21.2987 89.044 21.152C89.6893 21.0053 90.3347 20.932 90.98 20.932C92.6227 20.932 94.0893 21.3133 95.38 22.076C96.7 22.8387 97.7413 23.9093 98.504 25.288C99.296 26.6667 99.692 28.2653 99.692 30.084C99.692 32.02 99.2227 33.736 98.284 35.232C97.3747 36.6987 96.1133 37.8573 94.5 38.708C92.8867 39.5293 91.0093 39.94 88.868 39.94ZM85.48 24.144V21.636L94.412 11.472L99.34 11.428L90.144 21.856L85.48 24.144ZM80.772 12.66V8.964H99.34V11.428L95.732 12.66H80.772ZM115.844 39.94C113.82 39.94 112.001 39.4707 110.388 38.532C108.804 37.5933 107.542 36.332 106.604 34.748C105.665 33.164 105.196 31.404 105.196 29.468C105.196 26.7693 106.134 24.0853 108.012 21.416L116.988 8.964H121.784L112.588 21.504L111.092 22.296C111.444 21.68 111.869 21.1667 112.368 20.756C112.866 20.316 113.482 19.9787 114.216 19.744C114.949 19.5093 115.814 19.392 116.812 19.392C118.601 19.392 120.214 19.8173 121.652 20.668C123.118 21.5187 124.292 22.692 125.172 24.188C126.081 25.6547 126.536 27.3707 126.536 29.336C126.536 31.272 126.052 33.0467 125.084 34.66C124.145 36.2733 122.854 37.564 121.212 38.532C119.598 39.4707 117.809 39.94 115.844 39.94ZM115.844 36.068C117.076 36.068 118.176 35.7747 119.144 35.188C120.141 34.572 120.918 33.7653 121.476 32.768C122.062 31.7413 122.356 30.5973 122.356 29.336C122.356 28.0747 122.062 26.9453 121.476 25.948C120.918 24.9213 120.141 24.1147 119.144 23.528C118.176 22.9413 117.076 22.648 115.844 22.648C114.612 22.648 113.497 22.9413 112.5 23.528C111.532 24.1147 110.754 24.9213 110.168 25.948C109.61 26.9453 109.332 28.0747 109.332 29.336C109.332 30.5973 109.61 31.7413 110.168 32.768C110.754 33.7947 111.532 34.6013 112.5 35.188C113.497 35.7747 114.612 36.068 115.844 36.068ZM136.412 39.5V35.892H145.652C147.412 35.892 148.79 35.3787 149.788 34.352C150.785 33.296 151.284 32.0347 151.284 30.568C151.284 29.5707 151.064 28.676 150.624 27.884C150.184 27.0627 149.538 26.4173 148.688 25.948C147.866 25.4787 146.898 25.244 145.784 25.244H136.412V21.636H145.168C146.634 21.636 147.793 21.2547 148.644 20.492C149.524 19.7 149.964 18.5707 149.964 17.104C149.964 15.6373 149.509 14.5227 148.6 13.76C147.69 12.968 146.488 12.572 144.992 12.572H136.412V8.964H145.08C147.074 8.964 148.732 9.33067 150.052 10.064C151.401 10.768 152.413 11.7067 153.088 12.88C153.792 14.0533 154.144 15.344 154.144 16.752C154.144 18.3947 153.689 19.832 152.78 21.064C151.9 22.296 150.594 23.264 148.864 23.968L149.216 22.648C151.181 23.352 152.706 24.4227 153.792 25.86C154.906 27.268 155.464 28.94 155.464 30.876C155.464 32.4893 155.068 33.9413 154.276 35.232C153.484 36.5227 152.34 37.564 150.844 38.356C149.377 39.1187 147.573 39.5 145.432 39.5H136.412ZM133.64 39.5V8.964H137.776V39.5H133.64ZM162.11 39.5V8.084H166.07V39.5H162.11ZM183.172 39.94C181.118 39.94 179.27 39.456 177.628 38.488C175.985 37.52 174.68 36.2147 173.712 34.572C172.744 32.9 172.26 31.0373 172.26 28.984C172.26 26.96 172.744 25.1413 173.712 23.528C174.68 21.8853 175.985 20.58 177.628 19.612C179.27 18.644 181.118 18.16 183.172 18.16C185.196 18.16 187.029 18.644 188.672 19.612C190.344 20.5507 191.664 21.8413 192.632 23.484C193.6 25.1267 194.084 26.96 194.084 28.984C194.084 31.0373 193.6 32.9 192.632 34.572C191.664 36.2147 190.344 37.52 188.672 38.488C187.029 39.456 185.196 39.94 183.172 39.94ZM183.172 36.112C184.492 36.112 185.665 35.804 186.692 35.188C187.718 34.572 188.525 33.736 189.112 32.68C189.698 31.5947 189.992 30.3627 189.992 28.984C189.992 27.6347 189.684 26.432 189.068 25.376C188.481 24.32 187.674 23.4987 186.648 22.912C185.65 22.296 184.492 21.988 183.172 21.988C181.852 21.988 180.678 22.296 179.652 22.912C178.625 23.4987 177.818 24.32 177.232 25.376C176.645 26.432 176.352 27.6347 176.352 28.984C176.352 30.3627 176.645 31.5947 177.232 32.68C177.818 33.736 178.625 34.572 179.652 35.188C180.678 35.804 181.852 36.112 183.172 36.112ZM209.854 39.94C207.8 39.94 205.938 39.456 204.266 38.488C202.623 37.52 201.318 36.2147 200.35 34.572C199.411 32.9 198.942 31.052 198.942 29.028C198.942 26.9747 199.411 25.1267 200.35 23.484C201.318 21.8413 202.623 20.5507 204.266 19.612C205.938 18.644 207.8 18.16 209.854 18.16C211.467 18.16 212.963 18.468 214.342 19.084C215.72 19.6707 216.908 20.536 217.906 21.68L215.266 24.32C214.62 23.5573 213.828 22.9853 212.89 22.604C211.98 22.1933 210.968 21.988 209.854 21.988C208.534 21.988 207.36 22.296 206.334 22.912C205.307 23.4987 204.5 24.32 203.914 25.376C203.327 26.432 203.034 27.6493 203.034 29.028C203.034 30.4067 203.327 31.624 203.914 32.68C204.5 33.736 205.307 34.572 206.334 35.188C207.36 35.804 208.534 36.112 209.854 36.112C210.968 36.112 211.98 35.9213 212.89 35.54C213.828 35.1293 214.635 34.5427 215.31 33.78L217.906 36.42C216.938 37.5347 215.75 38.4 214.342 39.016C212.963 39.632 211.467 39.94 209.854 39.94ZM236.969 39.5L227.201 28.808L236.881 18.6H241.677L230.897 29.864L231.073 27.576L242.073 39.5H236.969ZM223.593 39.5V8.084H227.553V39.5H223.593ZM252.665 39.94C251.492 39.94 250.377 39.7933 249.321 39.5C248.294 39.1773 247.341 38.7373 246.461 38.18C245.581 37.5933 244.818 36.904 244.173 36.112L246.725 33.56C247.488 34.4987 248.368 35.2027 249.365 35.672C250.362 36.112 251.477 36.332 252.709 36.332C253.941 36.332 254.894 36.1267 255.569 35.716C256.244 35.276 256.581 34.6747 256.581 33.912C256.581 33.1493 256.302 32.5627 255.745 32.152C255.217 31.712 254.528 31.36 253.677 31.096C252.826 30.8027 251.917 30.524 250.949 30.26C250.01 29.9667 249.116 29.6 248.265 29.16C247.414 28.72 246.71 28.1187 246.153 27.356C245.625 26.5933 245.361 25.5813 245.361 24.32C245.361 23.0587 245.669 21.9733 246.285 21.064C246.901 20.1253 247.752 19.4067 248.837 18.908C249.952 18.4093 251.286 18.16 252.841 18.16C254.484 18.16 255.936 18.4533 257.197 19.04C258.488 19.5973 259.544 20.448 260.365 21.592L257.813 24.144C257.226 23.3813 256.493 22.7947 255.613 22.384C254.762 21.9733 253.794 21.768 252.709 21.768C251.565 21.768 250.685 21.9733 250.069 22.384C249.482 22.7653 249.189 23.308 249.189 24.012C249.189 24.716 249.453 25.2587 249.981 25.64C250.509 26.0213 251.198 26.344 252.049 26.608C252.929 26.872 253.838 27.1507 254.777 27.444C255.716 27.708 256.61 28.0747 257.461 28.544C258.312 29.0133 259.001 29.644 259.529 30.436C260.086 31.228 260.365 32.2693 260.365 33.56C260.365 35.5253 259.661 37.08 258.253 38.224C256.874 39.368 255.012 39.94 252.665 39.94Z" fill="${logoTextColor}"/></svg>`;
+
+        this.renderer.appendChild(poweredBy, poweredByText);
+        this.renderer.appendChild(poweredBy, logoSpan);
+        this.renderer.appendChild(element, poweredBy);
     }
 
     public hitCallbackUrl(callbackUrl: string, payload: { [key: string]: any }) {
@@ -1909,9 +1960,10 @@ export class ProxyAuthWidgetComponent extends BaseComponent implements OnInit, O
 
         const selectWidgetTheme = this.widgetTheme() as any;
         const primaryColor = this.getPrimaryColorForCurrentTheme(selectWidgetTheme?.ui_preferences);
-        const textColor = dark ? '#ffffff' : '#111827';
-        const border = dark ? '1px solid #ffffff' : '1px solid #000000';
-        const borderIconOnly = dark ? '1px solid #ffffff' : '1px solid #d1d5db';
+        const colors = dark ? THEME_COLORS.dark : THEME_COLORS.light;
+        const textColor = colors.buttonText;
+        const border = colors.buttonBorder;
+        const borderIconOnly = colors.buttonBorderIconOnly;
 
         container.querySelectorAll<HTMLButtonElement>('button[data-paw-button]').forEach((btn) => {
             const isIconOnly = btn.hasAttribute('data-paw-icon-only');
@@ -1934,6 +1986,15 @@ export class ProxyAuthWidgetComponent extends BaseComponent implements OnInit, O
         const createAccountP = container.querySelector<HTMLParagraphElement>('p[data-create-account="true"]');
         if (createAccountP) {
             createAccountP.style.setProperty('color', primaryColor, 'important');
+        }
+
+        const poweredByP = container.querySelector<HTMLParagraphElement>('p[data-powered-by="true"]');
+        if (poweredByP) {
+            poweredByP.style.setProperty('color', colors.poweredByLabel, 'important');
+            const textPath = poweredByP.querySelector<SVGPathElement>('svg path:last-child');
+            if (textPath) {
+                textPath.setAttribute('fill', colors.logoText);
+            }
         }
     }
 


### PR DESCRIPTION
…by 36Blocks" footer

- Extract theme-specific colors (buttonText, buttonBorder, poweredByLabel, logoText, primaryColorFallback) into THEME_COLORS constant for dark/light modes
- Refactor getPrimaryColorForCurrentTheme() and applyThemeToButtons() to use THEME_COLORS
- Add "Powered by 36Blocks" footer with SVG logo to appendCreateAccountLink()
- Apply theme-aware styling to powered-by footer in applyThemeToButtons()