### PR TITLE
Divyanshu | Fix back to last original page from all widget preview page

### DIFF
--- a/apps/36-blocks/src/app/features/create-feature/feature-preview/feature-preview.component.ts
+++ b/apps/36-blocks/src/app/features/create-feature/feature-preview/feature-preview.component.ts
@@ -16,7 +16,9 @@ export class FeaturePreviewComponent {
 
     public openPreview(): void {
         if (this.referenceId) {
-            this.router.navigate(['/widget-preview', this.referenceId]);
+            this.router.navigate(['/widget-preview', this.referenceId], {
+                state: { originUrl: this.router.url },
+            });
         }
     }
 }

--- a/apps/36-blocks/src/app/features/create-feature/feature-preview/widget-preview-dialog/widget-preview-dialog.component.ts
+++ b/apps/36-blocks/src/app/features/create-feature/feature-preview/widget-preview-dialog/widget-preview-dialog.component.ts
@@ -147,28 +147,47 @@ export class WidgetPreviewDialogComponent implements AfterViewInit {
         setTimeout(() => this.launchWidget());
     }
 
-    private resolveOriginUrl(): string | null {
+    private originStorageKey(): string | null {
         const refId = this.route.snapshot.paramMap.get('referenceId');
-        const storageKey = refId ? `widget_preview_origin_${refId}` : null;
+        return refId ? `widget_preview_origin_${refId}` : null;
+    }
+
+    private resolveOriginUrl(): string | null {
+        const storageKey = this.originStorageKey();
 
         const fromState = this.router.getCurrentNavigation()?.extras?.state?.['originUrl'] as string | undefined;
         if (fromState) {
-            if (storageKey) {
-                sessionStorage.setItem(storageKey, fromState);
+            try {
+                if (storageKey) {
+                    sessionStorage.setItem(storageKey, fromState);
+                }
+            } catch {
+                // sessionStorage unavailable (e.g. private browsing with storage blocked)
+                console.error('sessionStorage unavailable');
             }
             return fromState;
         }
 
-        if (storageKey) {
-            return sessionStorage.getItem(storageKey);
+        try {
+            if (storageKey) {
+                return sessionStorage.getItem(storageKey);
+            }
+        } catch {
+            // sessionStorage unavailable
+            console.error('sessionStorage unavailable');
         }
         return null;
     }
 
     public goBack(): void {
-        const refId = this.route.snapshot.paramMap.get('referenceId');
-        if (refId) {
-            sessionStorage.removeItem(`widget_preview_origin_${refId}`);
+        const storageKey = this.originStorageKey();
+        try {
+            if (storageKey) {
+                sessionStorage.removeItem(storageKey);
+            }
+        } catch {
+            // sessionStorage unavailable
+            console.error('sessionStorage unavailable');
         }
         if (this.originUrl) {
             this.router.navigateByUrl(this.originUrl);

--- a/apps/36-blocks/src/app/features/create-feature/feature-preview/widget-preview-dialog/widget-preview-dialog.component.ts
+++ b/apps/36-blocks/src/app/features/create-feature/feature-preview/widget-preview-dialog/widget-preview-dialog.component.ts
@@ -64,6 +64,7 @@ export class WidgetPreviewDialogComponent implements AfterViewInit {
     @ViewChild('drawer') drawer!: MatDrawer;
 
     public readonly isMobile = signal<boolean>(false);
+    private readonly originUrl: string | null;
 
     protected readonly PublicScriptType = PublicScriptType;
     protected readonly WidgetTheme = WidgetTheme;
@@ -108,6 +109,7 @@ export class WidgetPreviewDialogComponent implements AfterViewInit {
     ];
 
     constructor() {
+        this.originUrl = this.resolveOriginUrl();
         this.breakpointObserver
             .observe([Breakpoints.XSmall, Breakpoints.Small])
             .pipe(takeUntilDestroyed())
@@ -145,9 +147,31 @@ export class WidgetPreviewDialogComponent implements AfterViewInit {
         setTimeout(() => this.launchWidget());
     }
 
+    private resolveOriginUrl(): string | null {
+        const refId = this.route.snapshot.paramMap.get('referenceId');
+        const storageKey = refId ? `widget_preview_origin_${refId}` : null;
+
+        const fromState = this.router.getCurrentNavigation()?.extras?.state?.['originUrl'] as string | undefined;
+        if (fromState) {
+            if (storageKey) {
+                sessionStorage.setItem(storageKey, fromState);
+            }
+            return fromState;
+        }
+
+        if (storageKey) {
+            return sessionStorage.getItem(storageKey);
+        }
+        return null;
+    }
+
     public goBack(): void {
-        if (window.history.length > 1) {
-            this.location.back();
+        const refId = this.route.snapshot.paramMap.get('referenceId');
+        if (refId) {
+            sessionStorage.removeItem(`widget_preview_origin_${refId}`);
+        }
+        if (this.originUrl) {
+            this.router.navigateByUrl(this.originUrl);
         } else {
             this.router.navigate(['/app/features']);
         }

--- a/apps/36-blocks/src/app/features/feature/feature.component.html
+++ b/apps/36-blocks/src/app/features/feature/feature.component.html
@@ -135,7 +135,7 @@
                                 <div class="actions flex justify-end gap-3 pr-3">
                                     <button
                                         matButton="outlined"
-                                        [routerLink]="['/widget-preview', element.reference_id]"
+                                        (click)="navigateToPreview(element.reference_id)"
                                         class="mat-btn-md"
                                     >
                                         <mat-icon class="material-icons-outlined mat-icon-18 mat-icon-prefix"

--- a/apps/36-blocks/src/app/features/feature/feature.component.ts
+++ b/apps/36-blocks/src/app/features/feature/feature.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
@@ -55,6 +55,7 @@ import { IPaginatedResponse } from '@proxy/models/root-models';
 })
 export class FeatureComponent extends BaseComponent implements OnDestroy, OnInit {
     private componentStore = inject(FeatureComponentStore);
+    private router = inject(Router);
 
     /** Store Feature Data */
     public feature$: Observable<IPaginatedResponse<IFeature[]>> = this.componentStore.feature$;
@@ -112,5 +113,11 @@ export class FeatureComponent extends BaseComponent implements OnDestroy, OnInit
      */
     public getFeatures(): void {
         this.componentStore.getFeature({ ...this.params });
+    }
+
+    public navigateToPreview(referenceId: string): void {
+        this.router.navigate(['/widget-preview', referenceId], {
+            state: { originUrl: this.router.url },
+        });
     }
 }

--- a/apps/36-blocks/src/app/layout/layout.component.ts
+++ b/apps/36-blocks/src/app/layout/layout.component.ts
@@ -152,9 +152,6 @@ export class LayoutComponent extends BaseComponent implements OnInit, OnDestroy 
                     scriptElement.setAttribute('hideCloseButton', 'true');
 
                     scriptElement.onload = () => {
-                        if (this.router.url.startsWith('/widget-preview')) {
-                            return;
-                        }
                         const payload = {
                             variables: {
                                 variables: JSON.stringify({
@@ -167,6 +164,9 @@ export class LayoutComponent extends BaseComponent implements OnInit, OnDestroy 
                             fullScreen: true,
                         };
                         setTimeout(() => {
+                            if (this.router.url.startsWith('/widget-preview')) {
+                                return;
+                            }
                             (window as any).SendDataToChatbot(payload);
                             (window as any).openChatbot();
                         }, 2000);


### PR DESCRIPTION
…k button behavior

- Pass originUrl through navigation state when opening widget preview
- Add sessionStorage-based fallback for preserving origin URL across page refreshes
- Replace routerLink with click handler to pass navigation state in feature list
- Update goBack() to navigate to stored origin URL instead of using browser history
- Clean up sessionStorage when navigating back from preview
- Move widget-preview URL check inside setTimeout to prevent race condition in