### PR TITLE
Divyanshu | Add forgot password dialog with two-step flow in widget component

### DIFF
--- a/apps/36-blocks-widget/src/app/otp/widget/widget.component.html
+++ b/apps/36-blocks-widget/src/app/otp/widget/widget.component.html
@@ -32,46 +32,255 @@
         }
     </div>
 }
-@if (showRegistration() || showLogin()) {
+@if (showRegistration() || showLogin() || showForgotPassword()) {
     <div #dialogPortal [class.dark]="isDarkTheme()">
-        <div class="w-dialog-backdrop" (click)="closeOverlayDialog()" aria-hidden="true"></div>
-        <div role="dialog" aria-modal="true" class="w-dialog-panel" [class.w-dialog-panel--lg]="showRegistration()">
-            @if (isOtpLoading()) {
-                <proxy-progress-bar></proxy-progress-bar>
-            }
-            <div class="w-dialog-body">
-                @if (showRegistration()) {
-                    <proxy-register
-                        [referenceId]="referenceId"
-                        [serviceData]="otpWidgetData"
-                        [loginServiceData]="loginWidgetData"
-                        [registrationViaLogin]="registrationViaLogin"
-                        [showCompanyDetails]="showCompanyDetails"
-                        [version]="version"
-                        [theme]="theme"
-                        [prefillDetails]="prefillDetails"
-                        [firstName]="otherData?.firstName"
-                        [lastName]="otherData?.lastName"
-                        [email]="otherData?.email"
-                        [signupServiceId]="otherData?.signupServiceId"
-                        [isRegisterFormOnly]="isRegisterFormOnly"
-                        (togglePopUp)="closeOverlayDialog()"
-                        (successReturn)="closeOverlayDialog()"
-                        (failureReturn)="returnFailureObj($event)"
-                    ></proxy-register>
+        <div
+            class="w-dialog-backdrop"
+            (click)="showForgotPassword() ? closeForgotPasswordDialog() : closeOverlayDialog()"
+            aria-hidden="true"
+        ></div>
+
+        @if (showForgotPassword()) {
+            <div
+                role="dialog"
+                aria-labelledby="fp-dialog-title"
+                aria-modal="true"
+                class="w-dialog-panel w-dialog-panel--md"
+            >
+                <!-- Header -->
+                <div class="w-dialog-header">
+                    @if (forgotPasswordStep() === 2) {
+                        <button
+                            type="button"
+                            class="w-btn-close mr-2"
+                            (click)="goToForgotPasswordStep1()"
+                            aria-label="Back to step 1"
+                        >
+                            <svg class="size-4" aria-hidden="true" viewBox="0 -960 960 960" fill="currentColor">
+                                <path d="M400-80 0-480l400-400 71 71-329 329 329 329-71 71Z" />
+                            </svg>
+                        </button>
+                    }
+                    <h2 id="fp-dialog-title" class="w-dialog-title flex-1">
+                        {{ forgotPasswordStep() === 1 ? 'Reset Password' : 'Change Password' }}
+                    </h2>
+                    <button
+                        type="button"
+                        class="w-btn-close"
+                        (click)="closeForgotPasswordDialog()"
+                        aria-label="Close dialog"
+                    >
+                        <svg
+                            class="size-5"
+                            aria-hidden="true"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke-width="1.5"
+                            stroke="currentColor"
+                        >
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+                        </svg>
+                    </button>
+                </div>
+
+                <!-- Step 1: Email / Mobile input -->
+                @if (forgotPasswordStep() === 1) {
+                    <div class="w-dialog-body space-y-4">
+                        <p class="text-sm text-gray-500 dark:text-gray-400">
+                            Enter your email or mobile number to receive an OTP.
+                        </p>
+                        <div>
+                            <label for="fp-email" class="w-label">Email or Mobile</label>
+                            <input
+                                #fpEmailInput
+                                id="fp-email"
+                                type="text"
+                                autocomplete="off"
+                                [value]="forgotPasswordPrefillEmail()"
+                                placeholder="Email or Mobile"
+                                class="w-input"
+                                (keydown.enter)="sendForgotPasswordOtp(fpEmailInput.value, loginWidgetData)"
+                                aria-describedby="fp-email-error"
+                            />
+                            @if (forgotPasswordError()) {
+                                <p id="fp-email-error" role="alert" class="w-field-error">
+                                    {{ forgotPasswordError() }}
+                                </p>
+                            }
+                        </div>
+                    </div>
+                    <div class="w-dialog-footer">
+                        <button type="button" class="w-btn-secondary" (click)="closeForgotPasswordDialog()">
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            class="w-btn-primary"
+                            [disabled]="forgotPasswordLoading()"
+                            (click)="sendForgotPasswordOtp(fpEmailInput.value, loginWidgetData)"
+                        >
+                            @if (forgotPasswordLoading()) {
+                                <svg class="w-spinner" aria-hidden="true" fill="none" viewBox="0 0 24 24">
+                                    <circle
+                                        class="opacity-25"
+                                        cx="12"
+                                        cy="12"
+                                        r="10"
+                                        stroke="currentColor"
+                                        stroke-width="4"
+                                    />
+                                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
+                                </svg>
+                                Sending...
+                            } @else {
+                                Send OTP
+                            }
+                        </button>
+                    </div>
                 }
-                @if (showLogin()) {
-                    <proxy-login
-                        [loginServiceData]="loginWidgetData"
-                        [theme]="theme"
-                        (togglePopUp)="closeOverlayDialog()"
-                        (closePopUp)="closeOverlayDialog()"
-                        (openPopUp)="setShowRegistrationFromLogin($event)"
-                        (failureReturn)="returnFailureObj($event)"
-                    ></proxy-login>
+
+                <!-- Step 2: OTP + new password -->
+                @if (forgotPasswordStep() === 2) {
+                    <div class="w-dialog-body space-y-4">
+                        <div class="flex items-center justify-between text-sm">
+                            <span class="text-gray-500 dark:text-gray-400"
+                                >OTP sent to
+                                <span class="font-medium text-gray-900 dark:text-white">{{
+                                    forgotPasswordUser()
+                                }}</span></span
+                            >
+                            <button
+                                type="button"
+                                class="w-link"
+                                [disabled]="forgotPasswordResendSeconds() > 0"
+                                (click)="resendForgotPasswordOtp(loginWidgetData)"
+                            >
+                                {{
+                                    forgotPasswordResendSeconds() > 0
+                                        ? 'Resend in ' + forgotPasswordResendSeconds() + 's'
+                                        : 'Resend OTP'
+                                }}
+                            </button>
+                        </div>
+                        <div>
+                            <label for="fp-otp" class="w-label">OTP</label>
+                            <input
+                                #fpOtpInput
+                                id="fp-otp"
+                                type="number"
+                                autocomplete="off"
+                                placeholder="Enter OTP"
+                                class="w-input"
+                                aria-describedby="fp-change-error"
+                            />
+                        </div>
+                        <div>
+                            <label for="fp-password" class="w-label">New Password</label>
+                            <input
+                                #fpPasswordInput
+                                id="fp-password"
+                                type="password"
+                                autocomplete="new-password"
+                                placeholder="New Password"
+                                class="w-input"
+                            />
+                        </div>
+                        <div>
+                            <label for="fp-confirm" class="w-label">Confirm Password</label>
+                            <input
+                                #fpConfirmInput
+                                id="fp-confirm"
+                                type="password"
+                                autocomplete="new-password"
+                                placeholder="Confirm Password"
+                                class="w-input"
+                            />
+                        </div>
+                        <p class="text-xs text-gray-500 dark:text-gray-400">
+                            Min 8 chars · uppercase · lowercase · number · symbol
+                        </p>
+                        @if (forgotPasswordError()) {
+                            <p id="fp-change-error" role="alert" class="w-field-error">{{ forgotPasswordError() }}</p>
+                        }
+                    </div>
+                    <div class="w-dialog-footer">
+                        <button type="button" class="w-btn-secondary" (click)="closeForgotPasswordDialog()">
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            class="w-btn-primary"
+                            [disabled]="forgotPasswordLoading()"
+                            (click)="
+                                submitForgotPasswordChange(
+                                    fpOtpInput.value,
+                                    fpPasswordInput.value,
+                                    fpConfirmInput.value,
+                                    loginWidgetData
+                                )
+                            "
+                        >
+                            @if (forgotPasswordLoading()) {
+                                <svg class="w-spinner" aria-hidden="true" fill="none" viewBox="0 0 24 24">
+                                    <circle
+                                        class="opacity-25"
+                                        cx="12"
+                                        cy="12"
+                                        r="10"
+                                        stroke="currentColor"
+                                        stroke-width="4"
+                                    />
+                                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
+                                </svg>
+                                Saving...
+                            } @else {
+                                Change Password
+                            }
+                        </button>
+                    </div>
                 }
             </div>
-        </div>
+        }
+
+        @if (!showForgotPassword()) {
+            <div role="dialog" aria-modal="true" class="w-dialog-panel" [class.w-dialog-panel--lg]="showRegistration()">
+                @if (isOtpLoading()) {
+                    <proxy-progress-bar></proxy-progress-bar>
+                }
+                <div class="w-dialog-body">
+                    @if (showRegistration()) {
+                        <proxy-register
+                            [referenceId]="referenceId"
+                            [serviceData]="otpWidgetData"
+                            [loginServiceData]="loginWidgetData"
+                            [registrationViaLogin]="registrationViaLogin"
+                            [showCompanyDetails]="showCompanyDetails"
+                            [version]="version"
+                            [theme]="theme"
+                            [prefillDetails]="prefillDetails"
+                            [firstName]="otherData?.firstName"
+                            [lastName]="otherData?.lastName"
+                            [email]="otherData?.email"
+                            [signupServiceId]="otherData?.signupServiceId"
+                            [isRegisterFormOnly]="isRegisterFormOnly"
+                            (togglePopUp)="closeOverlayDialog()"
+                            (successReturn)="closeOverlayDialog()"
+                            (failureReturn)="returnFailureObj($event)"
+                        ></proxy-register>
+                    }
+                    @if (showLogin()) {
+                        <proxy-login
+                            [loginServiceData]="loginWidgetData"
+                            [theme]="theme"
+                            (togglePopUp)="closeOverlayDialog()"
+                            (closePopUp)="closeOverlayDialog()"
+                            (openPopUp)="setShowRegistrationFromLogin($event)"
+                            (failureReturn)="returnFailureObj($event)"
+                        ></proxy-login>
+                    }
+                </div>
+            </div>
+        }
     </div>
 }
 

--- a/apps/36-blocks-widget/src/app/otp/widget/widget.component.ts
+++ b/apps/36-blocks-widget/src/app/otp/widget/widget.component.ts
@@ -149,6 +149,14 @@ export class ProxyAuthWidgetComponent extends BaseComponent implements OnInit, O
     public readonly showRegistration = signal<boolean>(false);
     public readonly showForgotPassword = signal<boolean>(false);
     public readonly animate = signal<boolean>(false);
+
+    public readonly forgotPasswordStep = signal<1 | 2>(1);
+    public readonly forgotPasswordPrefillEmail = signal<string>('');
+    public readonly forgotPasswordUser = signal<string>('');
+    public readonly forgotPasswordLoading = signal<boolean>(false);
+    public readonly forgotPasswordError = signal<string>('');
+    public readonly forgotPasswordResendSeconds = signal<number>(0);
+    private forgotPasswordResendTimer: any = null;
     public isCreateAccountTextAppended: boolean = false;
     public otpWidgetData;
     public loginWidgetData;
@@ -310,6 +318,10 @@ export class ProxyAuthWidgetComponent extends BaseComponent implements OnInit, O
     public closeOverlayDialog(): void {
         this.dialogPortalRef?.detach();
         this.dialogPortalRef = null;
+        if (this.forgotPasswordResendTimer) {
+            clearInterval(this.forgotPasswordResendTimer);
+            this.forgotPasswordResendTimer = null;
+        }
         this.ngZone.run(() => {
             this.showRegistration.set(false);
             this.showForgotPassword.set(false);
@@ -827,8 +839,13 @@ export class ProxyAuthWidgetComponent extends BaseComponent implements OnInit, O
      */
     private openForgotPasswordDialog(prefillEmail: string = ''): void {
         this.ngZone.run(() => {
+            this.forgotPasswordStep.set(1);
+            this.forgotPasswordPrefillEmail.set(prefillEmail);
+            this.forgotPasswordUser.set('');
+            this.forgotPasswordLoading.set(false);
+            this.forgotPasswordError.set('');
+            this.forgotPasswordResendSeconds.set(0);
             this.showForgotPassword.set(true);
-            this.otpWidgetService.openForgotPassword(prefillEmail);
             this.cdr.detectChanges();
             setTimeout(() => {
                 if (this.dialogPortalEl?.nativeElement && !this.dialogPortalRef) {
@@ -838,485 +855,130 @@ export class ProxyAuthWidgetComponent extends BaseComponent implements OnInit, O
         });
     }
 
-    /**
-     * Shows the forgot password form (Step 2: Send OTP)
-     */
-    private showForgotPasswordForm(loginContainer: HTMLElement, buttonsData: any, prefillEmail: string = ''): void {
-        // Clear the login container
-        loginContainer.innerHTML = '';
-
-        const selectWidgetTheme = this.widgetTheme() as any;
-        const borderRadius = this.getBorderRadiusCssValue(selectWidgetTheme?.ui_preferences?.border_radius);
-        const isDarkFP = this.themeService.isDark();
-
-        // Create back button
-        const backButton: HTMLButtonElement = this.renderer.createElement('button');
-        backButton.type = 'button';
-        backButton.innerHTML = `
-            <svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 -960 960 960" width="16px" fill="#5f6368">
-                <path d="M400-80 0-480l400-400 71 71-329 329 329 329-71 71Z"/>
-            </svg>
-        `;
-        backButton.style.cssText = `
-            background: transparent;
-            border: none;
-            cursor: pointer;
-            padding: 4px;
-            display: flex;
-            align-items: center;
-            margin-bottom: 8px;
-        `;
-        backButton.addEventListener('click', () => {
-            this.restoreLoginForm(loginContainer, buttonsData);
-        });
-
-        // Create title
-        const title: HTMLElement = this.renderer.createElement('div');
-        title.textContent = 'Reset Password';
-        title.style.cssText = `
-            font-size: 16px;
-            line-height: 20px;
-            font-weight: 600;
-            color: ${isDarkFP ? '#ffffff' : '#1f2937'};
-            margin-bottom: 16px;
-        `;
-
-        // Create email/mobile input
-        const inputField = this.renderer.createElement('div');
-        inputField.style.cssText = `
-            display: flex;
-            flex-direction: column;
-            gap: 6px;
-            margin-bottom: 16px;
-        `;
-
-        const emailInput: HTMLInputElement = this.renderer.createElement('input');
-        emailInput.type = 'text';
-        emailInput.placeholder = 'Email or Mobile';
-        emailInput.autocomplete = 'off';
-        emailInput.value = prefillEmail;
-        emailInput.style.cssText = `
-            width: 100%;
-            height: 44px;
-            padding: 0 16px;
-            border: ${isDarkFP ? '1px solid #ffffff' : '1px solid #cbd5e1'};
-            border-radius: ${borderRadius};
-            background: ${isDarkFP ? 'transparent' : '#ffffff'};
-            color: ${isDarkFP ? '#ffffff' : '#1f2937'};
-            font-size: 14px;
-            outline: none;
-            box-sizing: border-box;
-        `;
-
-        // Create error text
-        const errorText: HTMLElement = this.renderer.createElement('div');
-        errorText.style.cssText = `
-            color: #d14343;
-            font-size: 14px;
-            min-height: 16px;
-            display: none;
-            margin-top: 4px;
-        `;
-
-        // Create send OTP button
-        const sendOtpButton: HTMLButtonElement = this.renderer.createElement('button');
-        sendOtpButton.textContent = 'Send OTP';
-        sendOtpButton.style.cssText = `
-            height: 44px;
-            padding: 0 12px;
-            background-color: #3f51b5;
-            color: #ffffff;
-            border: none;
-            border-radius: ${borderRadius};
-            font-size: 14px;
-            font-weight: 600;
-            cursor: pointer;
-            width: 100%;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.08);
-            margin-top: 8px;
-        `;
-
-        const handleSendOtp = () => {
-            const userDetails = emailInput.value?.trim();
-            if (!userDetails) {
-                this.domBuilder.setInlineError(errorText, 'Email or Mobile is required.');
-                return;
-            }
-
-            this.domBuilder.setInlineError(errorText, '');
-            const originalText = sendOtpButton.textContent || 'Send OTP';
-            sendOtpButton.disabled = true;
-            sendOtpButton.textContent = 'Please wait...';
-
-            const payload = {
-                state: buttonsData?.state || this.loginWidgetData?.state,
-                user: userDetails,
-            };
-
-            this.otpService.resetPassword(payload).subscribe(
-                (res) => {
-                    sendOtpButton.disabled = false;
-                    sendOtpButton.textContent = originalText;
-
-                    if (res?.hasError) {
-                        this.domBuilder.setInlineError(
-                            errorText,
-                            res?.errors?.[0] || 'Unable to send OTP. Please try again.'
-                        );
-                        return;
-                    }
-
-                    // Move to step 3: Change Password
-                    this.showChangePasswordForm(loginContainer, buttonsData, userDetails);
-                },
-                (error) => {
-                    sendOtpButton.disabled = false;
-                    sendOtpButton.textContent = originalText;
-                    this.domBuilder.setInlineError(
-                        errorText,
-                        error?.error?.errors?.[0] || 'Failed to send OTP. Please try again.'
-                    );
-                }
-            );
-        };
-
-        sendOtpButton.addEventListener('click', handleSendOtp);
-        emailInput.addEventListener('keydown', (event: KeyboardEvent) => {
-            if (event.key === 'Enter') {
-                event.preventDefault();
-                handleSendOtp();
-            }
-        });
-
-        // Append elements
-        this.renderer.appendChild(inputField, emailInput);
-        this.renderer.appendChild(loginContainer, backButton);
-        this.renderer.appendChild(loginContainer, title);
-        this.renderer.appendChild(loginContainer, inputField);
-        this.renderer.appendChild(loginContainer, errorText);
-        this.renderer.appendChild(loginContainer, sendOtpButton);
+    public closeForgotPasswordDialog(): void {
+        if (this.forgotPasswordResendTimer) {
+            clearInterval(this.forgotPasswordResendTimer);
+            this.forgotPasswordResendTimer = null;
+        }
+        this.showForgotPassword.set(false);
+        this.forgotPasswordError.set('');
+        this.cdr.detectChanges();
     }
 
-    /**
-     * Shows the change password form (Step 3: Enter OTP and new password)
-     */
-    private showChangePasswordForm(loginContainer: HTMLElement, buttonsData: any, userDetails: string): void {
-        // Clear the login container
-        loginContainer.innerHTML = '';
+    public goToForgotPasswordStep1(): void {
+        this.forgotPasswordStep.set(1);
+        this.forgotPasswordError.set('');
+    }
 
-        const selectWidgetTheme = this.widgetTheme() as any;
-        const borderRadius = this.getBorderRadiusCssValue(selectWidgetTheme?.ui_preferences?.border_radius);
-        const isDarkCP = this.themeService.isDark();
-
-        let remainingSeconds = 15;
-        let timerInterval: any = null;
-
-        // Create back button
-        const backButton: HTMLButtonElement = this.renderer.createElement('button');
-        backButton.type = 'button';
-        backButton.innerHTML = `
-            <svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 -960 960 960" width="16px" fill="#5f6368">
-                <path d="M400-80 0-480l400-400 71 71-329 329 329 329-71 71Z"/>
-            </svg>
-        `;
-        backButton.style.cssText = `
-            background: transparent;
-            border: none;
-            cursor: pointer;
-            padding: 4px;
-            display: flex;
-            align-items: center;
-            margin-bottom: 8px;
-        `;
-        backButton.addEventListener('click', () => {
-            if (timerInterval) clearInterval(timerInterval);
-            this.showForgotPasswordForm(loginContainer, buttonsData, userDetails);
-        });
-
-        // Create title
-        const title: HTMLElement = this.renderer.createElement('div');
-        title.textContent = 'Change Password';
-        title.style.cssText = `
-            font-size: 16px;
-            line-height: 20px;
-            font-weight: 600;
-            color: ${isDarkCP ? '#ffffff' : '#1f2937'};
-            margin-bottom: 8px;
-        `;
-
-        // User info with change link
-        const userInfo: HTMLElement = this.renderer.createElement('p');
-        userInfo.style.cssText = `
-            font-size: 14px;
-            color: ${isDarkCP ? '#e5e7eb' : '#5d6164'};
-            margin: 0 0 8px 0;
-        `;
-        userInfo.innerHTML = `${userDetails} <a href="javascript:void(0)" style="color: #1976d2; text-decoration: none;">Change</a>`;
-        userInfo.querySelector('a')?.addEventListener('click', () => {
-            if (timerInterval) clearInterval(timerInterval);
-            this.showForgotPasswordForm(loginContainer, buttonsData, userDetails);
-        });
-
-        // Resend OTP button
-        const resendButton: HTMLButtonElement = this.renderer.createElement('button');
-        resendButton.type = 'button';
-        resendButton.style.cssText = `
-            background: transparent;
-            border: none;
-            color: #1976d2;
-            font-size: 14px;
-            cursor: pointer;
-            padding: 4px 0;
-            margin-bottom: 12px;
-        `;
-
-        const updateResendButton = () => {
-            if (remainingSeconds > 0) {
-                resendButton.textContent = `Resend OTP ${remainingSeconds}`;
-                resendButton.disabled = true;
-                resendButton.style.opacity = '0.6';
-            } else {
-                resendButton.textContent = 'Resend OTP';
-                resendButton.disabled = false;
-                resendButton.style.opacity = '1';
+    public sendForgotPasswordOtp(emailValue: string, buttonsData: any): void {
+        const userDetails = emailValue?.trim();
+        if (!userDetails) {
+            this.forgotPasswordError.set('Email or Mobile is required.');
+            return;
+        }
+        this.forgotPasswordError.set('');
+        this.forgotPasswordLoading.set(true);
+        const payload = { state: buttonsData?.state || this.loginWidgetData?.state, user: userDetails };
+        this.otpService.resetPassword(payload).subscribe(
+            (res) => {
+                this.forgotPasswordLoading.set(false);
+                if (res?.hasError) {
+                    this.forgotPasswordError.set(res?.errors?.[0] || 'Unable to send OTP. Please try again.');
+                    return;
+                }
+                this.forgotPasswordUser.set(userDetails);
+                this.forgotPasswordStep.set(2);
+                this.forgotPasswordError.set('');
+                this.startForgotPasswordResendTimer();
+            },
+            (error) => {
+                this.forgotPasswordLoading.set(false);
+                this.forgotPasswordError.set(error?.error?.errors?.[0] || 'Failed to send OTP. Please try again.');
             }
-        };
-        updateResendButton();
+        );
+    }
 
-        // Start timer
-        timerInterval = setInterval(() => {
-            if (remainingSeconds > 0) {
-                remainingSeconds--;
-                updateResendButton();
+    public resendForgotPasswordOtp(buttonsData: any): void {
+        if (this.forgotPasswordResendSeconds() > 0) return;
+        const payload = { state: buttonsData?.state || this.loginWidgetData?.state, user: this.forgotPasswordUser() };
+        this.otpService.resetPassword(payload).subscribe(
+            (res) => {
+                if (!res?.hasError) {
+                    this.startForgotPasswordResendTimer();
+                }
+            },
+            () => {}
+        );
+    }
+
+    private startForgotPasswordResendTimer(): void {
+        if (this.forgotPasswordResendTimer) clearInterval(this.forgotPasswordResendTimer);
+        this.forgotPasswordResendSeconds.set(15);
+        this.forgotPasswordResendTimer = setInterval(() => {
+            const remainingSeconds = this.forgotPasswordResendSeconds() - 1;
+            if (remainingSeconds <= 0) {
+                clearInterval(this.forgotPasswordResendTimer);
+                this.forgotPasswordResendTimer = null;
+                this.forgotPasswordResendSeconds.set(0);
             } else {
-                clearInterval(timerInterval);
+                this.forgotPasswordResendSeconds.set(remainingSeconds);
             }
         }, 1000);
+    }
 
-        resendButton.addEventListener('click', () => {
-            if (remainingSeconds > 0) return;
-
-            resendButton.disabled = true;
-            const payload = {
-                state: buttonsData?.state || this.loginWidgetData?.state,
-                user: userDetails,
-            };
-
-            this.otpService.resetPassword(payload).subscribe(
-                (res) => {
-                    if (!res?.hasError) {
-                        remainingSeconds = 15;
-                        updateResendButton();
-                        timerInterval = setInterval(() => {
-                            if (remainingSeconds > 0) {
-                                remainingSeconds--;
-                                updateResendButton();
-                            } else {
-                                clearInterval(timerInterval);
-                            }
-                        }, 1000);
-                    }
-                    resendButton.disabled = remainingSeconds > 0;
-                },
-                () => {
-                    resendButton.disabled = false;
-                }
-            );
-        });
-
-        // Create OTP input
-        const otpInput: HTMLInputElement = this.renderer.createElement('input');
-        otpInput.type = 'number';
-        otpInput.placeholder = 'Enter OTP';
-        otpInput.autocomplete = 'off';
-        otpInput.style.cssText = `
-            width: 100%;
-            height: 44px;
-            padding: 0 16px;
-            border: ${isDarkCP ? '1px solid #ffffff' : '1px solid #cbd5e1'};
-            border-radius: ${borderRadius};
-            background: ${isDarkCP ? 'transparent' : '#ffffff'};
-            color: ${isDarkCP ? '#ffffff' : '#1f2937'};
-            font-size: 14px;
-            outline: none;
-            box-sizing: border-box;
-            margin-bottom: 12px;
-        `;
-
-        // Create password input
-        const passwordInput: HTMLInputElement = this.renderer.createElement('input');
-        passwordInput.type = 'password';
-        passwordInput.placeholder = 'New Password';
-        passwordInput.autocomplete = 'off';
-        passwordInput.style.cssText = otpInput.style.cssText;
-
-        // Create confirm password input
-        const confirmPasswordInput: HTMLInputElement = this.renderer.createElement('input');
-        confirmPasswordInput.type = 'password';
-        confirmPasswordInput.placeholder = 'Confirm Password';
-        confirmPasswordInput.autocomplete = 'off';
-        confirmPasswordInput.style.cssText = otpInput.style.cssText;
-
-        // Password hint
-        const passwordHint: HTMLElement = this.renderer.createElement('p');
-        passwordHint.textContent =
-            'Password should contain at least one Capital Letter, one Small Letter, one Digit and one Symbol (min 8 characters)';
-        passwordHint.style.cssText = `
-            font-size: 12px;
-            color: ${isDarkCP ? '#9ca3af' : '#6b7280'};
-            margin: -8px 0 12px 0;
-        `;
-
-        // Create error text
-        const errorText: HTMLElement = this.renderer.createElement('div');
-        errorText.style.cssText = `
-            color: #d14343;
-            font-size: 14px;
-            min-height: 16px;
-            display: none;
-            margin-bottom: 8px;
-        `;
-
-        // Create submit button
-        const submitButton: HTMLButtonElement = this.renderer.createElement('button');
-        submitButton.textContent = 'Submit';
-        submitButton.style.cssText = `
-            height: 44px;
-            padding: 0 12px;
-            background-color: #3f51b5;
-            color: #ffffff;
-            border: none;
-            border-radius: ${borderRadius};
-            font-size: 14px;
-            font-weight: 600;
-            cursor: pointer;
-            width: 100%;
-            box-shadow: 0 1px 2px rgba(0,0,0,0.08);
-        `;
-
+    public submitForgotPasswordChange(otp: string, password: string, confirmPassword: string, buttonsData: any): void {
         const PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]).{8,}$/;
-
-        const handleSubmit = () => {
-            const otp = otpInput.value?.trim();
-            const password = passwordInput.value;
-            const confirmPassword = confirmPasswordInput.value;
-
-            if (!otp) {
-                this.domBuilder.setInlineError(errorText, 'OTP is required.');
-                return;
-            }
-            if (!password) {
-                this.domBuilder.setInlineError(errorText, 'Password is required.');
-                return;
-            }
-            if (password.length < 8) {
-                this.domBuilder.setInlineError(errorText, 'Password must be at least 8 characters.');
-                return;
-            }
-            if (!PASSWORD_REGEX.test(password)) {
-                this.domBuilder.setInlineError(
-                    errorText,
-                    'Password should contain at least one Capital Letter, one Small Letter, one Digit and one Symbol.'
-                );
-                return;
-            }
-            if (password !== confirmPassword) {
-                this.domBuilder.setInlineError(errorText, 'Passwords do not match.');
-                return;
-            }
-
-            this.domBuilder.setInlineError(errorText, '');
-            const originalText = submitButton.textContent || 'Submit';
-            submitButton.disabled = true;
-            submitButton.textContent = 'Please wait...';
-
-            const encodedPassword = this.encryptPassword(password);
-            const payload = {
-                state: buttonsData?.state || this.loginWidgetData?.state,
-                user: userDetails,
-                password: encodedPassword,
-                otp: parseInt(otp, 10),
-            };
-
-            this.otpService.verfyResetPasswordOtp(payload).subscribe(
-                (res) => {
-                    submitButton.disabled = false;
-                    submitButton.textContent = originalText;
-
-                    if (res?.hasError) {
-                        this.domBuilder.setInlineError(
-                            errorText,
-                            res?.errors?.[0] || 'Unable to reset password. Please try again.'
-                        );
-                        return;
-                    }
-
-                    // Clear timer and go back to login form
-                    if (timerInterval) clearInterval(timerInterval);
-                    this.restoreLoginForm(loginContainer, buttonsData);
-                },
-                (error) => {
-                    submitButton.disabled = false;
-                    submitButton.textContent = originalText;
-                    this.domBuilder.setInlineError(
-                        errorText,
-                        error?.error?.errors?.[0] || 'Failed to reset password. Please try again.'
-                    );
-                }
-            );
-        };
-
-        submitButton.addEventListener('click', handleSubmit);
-
-        // Append elements
-        this.renderer.appendChild(loginContainer, backButton);
-        this.renderer.appendChild(loginContainer, title);
-        this.renderer.appendChild(loginContainer, userInfo);
-        this.renderer.appendChild(loginContainer, resendButton);
-        this.renderer.appendChild(loginContainer, otpInput);
-        this.renderer.appendChild(loginContainer, passwordInput);
-        this.renderer.appendChild(loginContainer, confirmPasswordInput);
-        this.renderer.appendChild(loginContainer, passwordHint);
-        this.renderer.appendChild(loginContainer, errorText);
-        this.renderer.appendChild(loginContainer, submitButton);
-    }
-
-    /**
-     * Restores the login form after forgot password flow
-     */
-    private restoreLoginForm(loginContainer: HTMLElement, buttonsData: any): void {
-        // Clear the container and rebuild the login form content
-        loginContainer.innerHTML = '';
-
-        // Rebuild the login form content within the same container
-        this.buildLoginFormContent(loginContainer, buttonsData);
-    }
-
-    private buildLoginFormContent(loginContainer: HTMLElement, buttonsData: any): void {
-        const selectWidgetTheme = this.widgetTheme() as any;
-        const borderRadius = this.getBorderRadiusCssValue(selectWidgetTheme?.ui_preferences?.border_radius);
-        const primaryColor = this.getPrimaryColorForCurrentTheme(selectWidgetTheme?.ui_preferences);
-
-        const title: HTMLElement = this.renderer.createElement('div');
-        title.textContent = 'Login';
-        title.style.cssText = `font-size:16px;line-height:20px;font-weight:600;color:${
-            this.themeService.isDark() ? '#ffffff' : '#1f2937'
-        };margin-bottom:0;text-align:center;`;
-
-        const loginButton: HTMLButtonElement = this.renderer.createElement('button');
-        loginButton.textContent = 'Login';
-        loginButton.style.cssText = `height:44px;padding:0 12px;background-color:#3f51b5;color:#ffffff;border:none;border-radius:${borderRadius};font-size:14px;font-weight:600;cursor:pointer;width:100%;box-shadow:0 1px 2px rgba(0,0,0,0.08);margin-top:4px;`;
-
-        const onForgotPassword = (email: string) => this.showForgotPasswordForm(loginContainer, buttonsData, email);
-
-        const logoUrl = selectWidgetTheme?.ui_preferences?.logo_url;
-        const logoElement = this.domBuilder.createLogoElement(this.renderer, logoUrl);
-        if (logoElement) {
-            this.renderer.appendChild(loginContainer, logoElement);
+        if (!otp?.trim()) {
+            this.forgotPasswordError.set('OTP is required.');
+            return;
         }
-        this.renderer.appendChild(loginContainer, title);
-
-        this.buildLoginFields(loginContainer, buttonsData, loginButton, borderRadius, primaryColor, onForgotPassword);
+        if (!password) {
+            this.forgotPasswordError.set('Password is required.');
+            return;
+        }
+        if (password.length < 8) {
+            this.forgotPasswordError.set('Password must be at least 8 characters.');
+            return;
+        }
+        if (!PASSWORD_REGEX.test(password)) {
+            this.forgotPasswordError.set(
+                'Password should contain at least one Capital Letter, one Small Letter, one Digit and one Symbol.'
+            );
+            return;
+        }
+        if (password !== confirmPassword) {
+            this.forgotPasswordError.set('Passwords do not match.');
+            return;
+        }
+        this.forgotPasswordError.set('');
+        this.forgotPasswordLoading.set(true);
+        const encodedPassword = this.encryptPassword(password);
+        const payload = {
+            state: buttonsData?.state || this.loginWidgetData?.state,
+            user: this.forgotPasswordUser(),
+            password: encodedPassword,
+            otp: parseInt(otp, 10),
+        };
+        this.otpService.verfyResetPasswordOtp(payload).subscribe(
+            (res) => {
+                this.forgotPasswordLoading.set(false);
+                if (res?.hasError) {
+                    this.forgotPasswordError.set(res?.errors?.[0] || 'Unable to reset password. Please try again.');
+                    return;
+                }
+                if (this.forgotPasswordResendTimer) {
+                    clearInterval(this.forgotPasswordResendTimer);
+                    this.forgotPasswordResendTimer = null;
+                }
+                this.closeForgotPasswordDialog();
+            },
+            (error) => {
+                this.forgotPasswordLoading.set(false);
+                this.forgotPasswordError.set(
+                    error?.error?.errors?.[0] || 'Failed to reset password. Please try again.'
+                );
+            }
+        );
     }
 
     private buildLoginFields(


### PR DESCRIPTION
- widget.component.html: add dedicated forgot password dialog with step 1 (email/mobile input) and step 2 (OTP + new password), update backdrop click handler to use closeForgotPasswordDialog when in forgot password mode, wrap existing registration/login dialogs in conditional block
- widget.component.ts: add signals for forgot password state (step, prefillEmail, user, loading, error, resendSeconds), add methods for sendForgotPasswordO