### PR TITLE
refactor: remove base64 decoding from AES decrypt in OtpUtilityService

### DIFF
--- a/apps/36-blocks-widget/src/app/otp/service/otp-utility.service.ts
+++ b/apps/36-blocks-widget/src/app/otp/service/otp-utility.service.ts
@@ -14,15 +14,11 @@ export class OtpUtilityService {
     }
 
     public aesDecrypt(encodedData: string, encodeKey: string, ivKey: string, isBase64Encoded?: boolean): any {
-        const cipher = CryptoJS.AES.decrypt(
-            isBase64Encoded ? atob(encodedData) : encodedData,
-            CryptoJS.enc.Utf8.parse(encodeKey),
-            {
-                iv: CryptoJS.enc.Utf8.parse(ivKey),
-                mode: CryptoJS.mode.CBC,
-                padding: CryptoJS.pad.Pkcs7,
-            }
-        );
+        const cipher = CryptoJS.AES.decrypt(encodedData, CryptoJS.enc.Utf8.parse(encodeKey), {
+            iv: CryptoJS.enc.Utf8.parse(ivKey),
+            mode: CryptoJS.mode.CBC,
+            padding: CryptoJS.pad.Pkcs7,
+        });
         return cipher.toString(CryptoJS.enc.Utf8);
     }
 }


### PR DESCRIPTION
- otp-utility.service.ts: remove atob() call and isBase64Encoded conditional, pass encodedData directly to AES.decrypt