### PR TITLE
Divyanshu | refactor: restructure routing to move app routes to top level and configure SSR render modes

### DIFF
--- a/apps/36-blocks/src/app/app.routes.server.ts
+++ b/apps/36-blocks/src/app/app.routes.server.ts
@@ -6,6 +6,22 @@ export const serverRoutes: ServerRoute[] = [
         renderMode: RenderMode.Prerender,
     },
     {
+        path: 'app/**',
+        renderMode: RenderMode.Client,
+    },
+    {
+        path: 'widget-preview/**',
+        renderMode: RenderMode.Client,
+    },
+    {
+        path: 'project',
+        renderMode: RenderMode.Client,
+    },
+    {
+        path: 'client/**',
+        renderMode: RenderMode.Client,
+    },
+    {
         path: '**',
         renderMode: RenderMode.Client,
     },

--- a/apps/36-blocks/src/app/app.routes.ts
+++ b/apps/36-blocks/src/app/app.routes.ts
@@ -1,10 +1,13 @@
 import { Component, inject } from '@angular/core';
 import { Route, Router } from '@angular/router';
+import { AngularFireAuthGuard, redirectUnauthorizedTo } from '@angular/fire/compat/auth-guard';
 import { CookieService } from 'ngx-cookie-service';
 import { AuthService } from '@proxy/services/proxy/auth';
 
 @Component({ template: '', standalone: true })
 class NotFoundRedirectComponent {}
+
+const redirectUnauthorizedToLogin = () => redirectUnauthorizedTo(['login']);
 
 export const appRoutes: Route[] = [
     {
@@ -12,8 +15,34 @@ export const appRoutes: Route[] = [
         loadChildren: () => import('./website/website.routes').then((r) => r.websiteRoutes),
     },
     {
-        path: '',
+        path: 'app',
         loadChildren: () => import('./panel/panel.routes').then((r) => r.panelRoutes),
+    },
+    {
+        path: 'widget-preview/:referenceId',
+        loadComponent: () =>
+            import('./panel/features/create-feature/feature-preview/widget-preview/widget-preview.component').then(
+                (c) => c.WidgetPreviewComponent
+            ),
+        data: { authGuardPipe: redirectUnauthorizedToLogin },
+        canActivate: [AngularFireAuthGuard],
+    },
+    {
+        path: 'project',
+        loadComponent: () =>
+            import('./panel/create-project/create-project.component').then((c) => c.CreateProjectComponent),
+        data: { authGuardPipe: redirectUnauthorizedToLogin },
+        canActivate: [AngularFireAuthGuard],
+    },
+    {
+        path: 'client',
+        children: [
+            {
+                path: 'registration',
+                loadComponent: () =>
+                    import('./core/registration/registration.component').then((c) => c.RegistrationComponent),
+            },
+        ],
     },
     {
         path: '**',

--- a/apps/36-blocks/src/app/core/auth-initializer.service.ts
+++ b/apps/36-blocks/src/app/core/auth-initializer.service.ts
@@ -1,5 +1,4 @@
-import { inject, Injectable, PLATFORM_ID } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
+import { inject, Injectable } from '@angular/core';
 import { CookieService } from 'ngx-cookie-service';
 import { AuthService } from '@proxy/services/proxy/auth';
 
@@ -7,12 +6,8 @@ import { AuthService } from '@proxy/services/proxy/auth';
 export class AuthInitializerService {
     private readonly cookieService = inject(CookieService);
     private readonly authService = inject(AuthService);
-    private readonly platformId = inject(PLATFORM_ID);
 
     initialize(): void {
-        if (!isPlatformBrowser(this.platformId)) {
-            return;
-        }
         const existingToken = this.cookieService.get('authToken');
         if (existingToken) {
             this.authService.setTokenSync(existingToken);

--- a/apps/36-blocks/src/app/panel/panel.routes.ts
+++ b/apps/36-blocks/src/app/panel/panel.routes.ts
@@ -1,5 +1,5 @@
 import { Route } from '@angular/router';
-import { AngularFireAuthGuard, redirectUnauthorizedTo } from '@angular/fire/compat/auth-guard';
+import { redirectUnauthorizedTo } from '@angular/fire/compat/auth-guard';
 import { CanActivateRouteGuard } from '../website/home/authguard';
 import { ProjectGuard } from './guard/project.guard';
 
@@ -7,7 +7,7 @@ const redirectUnauthorizedToLogin = () => redirectUnauthorizedTo(['login']);
 
 export const panelRoutes: Route[] = [
     {
-        path: 'app',
+        path: '',
         loadComponent: () => import('./layout/layout.component').then((c) => c.LayoutComponent),
         children: [
             { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
@@ -34,30 +34,5 @@ export const panelRoutes: Route[] = [
         ],
         data: { authGuardPipe: redirectUnauthorizedToLogin },
         canActivate: [CanActivateRouteGuard, ProjectGuard],
-    },
-    {
-        path: 'widget-preview/:referenceId',
-        loadComponent: () =>
-            import('./features/create-feature/feature-preview/widget-preview/widget-preview.component').then(
-                (c) => c.WidgetPreviewComponent
-            ),
-        data: { authGuardPipe: redirectUnauthorizedToLogin },
-        canActivate: [AngularFireAuthGuard],
-    },
-    {
-        path: 'project',
-        loadComponent: () => import('./create-project/create-project.component').then((c) => c.CreateProjectComponent),
-        data: { authGuardPipe: redirectUnauthorizedToLogin },
-        canActivate: [AngularFireAuthGuard],
-    },
-    {
-        path: 'client',
-        children: [
-            {
-                path: 'registration',
-                loadComponent: () =>
-                    import('../core/registration/registration.component').then((c) => c.RegistrationComponent),
-            },
-        ],
     },
 ];

--- a/apps/36-blocks/src/app/website/home/authguard/logged-in.guard.ts
+++ b/apps/36-blocks/src/app/website/home/authguard/logged-in.guard.ts
@@ -1,5 +1,4 @@
-import { inject, Injectable, PLATFORM_ID } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
+import { inject, Injectable } from '@angular/core';
 import { Router, UrlTree } from '@angular/router';
 import { CookieService } from 'ngx-cookie-service';
 import { AuthService } from '@proxy/services/proxy/auth';
@@ -9,12 +8,8 @@ export class LoggedInGuard {
     private readonly cookieService = inject(CookieService);
     private readonly authService = inject(AuthService);
     private readonly router = inject(Router);
-    private readonly platformId = inject(PLATFORM_ID);
 
     canActivate(): boolean | UrlTree {
-        if (!isPlatformBrowser(this.platformId)) {
-            return true;
-        }
         const cookieToken = this.cookieService.get('authToken');
         const memoryToken = this.authService.getTokenSync();
         if (cookieToken || memoryToken) {


### PR DESCRIPTION
- Move app, widget-preview, project, and client routes from panel.routes to app.routes
- Set panel routes base path from 'app' to '' (empty)
- Configure server-side rendering modes: set app/**, widget-preview/**, project, and client/** to Client render mode
- Remove platform browser checks from AuthInitializerService and LoggedInGuard
- Remove unused PLATFORM_ID and isPlatformBrowser imports
- Remove unused AngularFireAuthGuard import from