### PR TITLE
Divyanshu | refactor: show all log sections by default when log settings are undefined

### DIFF
--- a/apps/36-blocks/src/app/panel/logs/log-details-side-dialog/log-details-side-dialog.component.html
+++ b/apps/36-blocks/src/app/panel/logs/log-details-side-dialog/log-details-side-dialog.component.html
@@ -11,19 +11,19 @@
 @if (data) {
     <mat-dialog-content>
         @if (data.logData$ | async; as logdata) {
-            @if (data?.logSettings?.store_headers) {
+            @if (!data?.logSettings || data?.logSettings?.store_headers) {
                 <ng-container
                     [ngTemplateOutlet]="jsonCard"
                     [ngTemplateOutletContext]="{ title: 'Headers', jsonData: logdata?.headers }"
                 ></ng-container>
             }
-            @if (data?.logSettings?.store_requestBody) {
+            @if (!data?.logSettings || data?.logSettings?.store_requestBody) {
                 <ng-container
                     [ngTemplateOutlet]="jsonCard"
                     [ngTemplateOutletContext]="{ title: 'Request body', jsonData: logdata?.request_body }"
                 ></ng-container>
             }
-            @if (data?.logSettings?.store_response) {
+            @if (!data?.logSettings || data?.logSettings?.store_response) {
                 <ng-container
                     [ngTemplateOutlet]="jsonCard"
                     [ngTemplateOutletContext]="{ title: 'Response', jsonData: logdata?.response }"

--- a/apps/36-blocks/src/app/panel/logs/log-details-side-dialog/log-details-side-dialog.component.html
+++ b/apps/36-blocks/src/app/panel/logs/log-details-side-dialog/log-details-side-dialog.component.html
@@ -2,14 +2,17 @@
     <proxy-loader></proxy-loader>
 }
 <!-- Top Fixed Header::START -->
-<div matDialogContent>
-    <h2 class="mat-title mat-subheading-2 mb-0 text-dark">Logs Details</h2>
+<div class="flex items-center justify-between pe-5">
+    <h2 mat-dialog-title class="mat-title mat-subheading-2 mb-0 text-dark">Logs Details</h2>
+    <button matIconButton (click)="onCloseDialog()" role="button">
+        <mat-icon>close</mat-icon>
+    </button>
 </div>
 <!-- Top Fixed Header::END -->
 
 <!-- Content::START -->
 @if (data) {
-    <mat-dialog-content>
+    <mat-dialog-content class="!max-h-[calc(100vh-100px)] overflow-y-auto !py-3">
         @if (data.logData$ | async; as logdata) {
             @if (!data?.logSettings || data?.logSettings?.store_headers) {
                 <ng-container
@@ -36,9 +39,6 @@
         }
     </mat-dialog-content>
 }
-<mat-dialog-actions align="end">
-    <button mat-button (click)="onCloseDialog()">Close</button>
-</mat-dialog-actions>
 
 <ng-template #jsonCard let-title="title" let-jsonData="jsonData">
     <span class="mb-2 mt-1 mat-body-2 font-medium">{{ title }}</span>

--- a/apps/36-blocks/src/app/panel/logs/log-details-side-dialog/log-details-side-dialog.component.ts
+++ b/apps/36-blocks/src/app/panel/logs/log-details-side-dialog/log-details-side-dialog.component.ts
@@ -2,8 +2,10 @@ import { ChangeDetectionStrategy, Component, OnDestroy, inject } from '@angular/
 import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatCardModule } from '@angular/material/card';
 import { MatDialogModule } from '@angular/material/dialog';
 import { LoaderComponent } from '@proxy/ui/loader';
+import { NoRecordFoundComponent } from '@proxy/ui/no-record-found';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { ILogDetailRes } from '@proxy/models/logs-models';
 import { BaseComponent } from '@proxy/ui/base-component';
@@ -12,7 +14,16 @@ import { Observable } from 'rxjs';
 @Component({
     changeDetection: ChangeDetectionStrategy.OnPush,
     selector: 'proxy-log-details-side-dialog',
-    imports: [AsyncPipe, NgTemplateOutlet, MatButtonModule, MatIconModule, MatDialogModule, LoaderComponent],
+    imports: [
+        AsyncPipe,
+        NgTemplateOutlet,
+        MatButtonModule,
+        MatIconModule,
+        MatCardModule,
+        MatDialogModule,
+        LoaderComponent,
+        NoRecordFoundComponent,
+    ],
     templateUrl: './log-details-side-dialog.component.html',
     styleUrls: ['./log-details-side-dialog.component.scss'],
 })

--- a/apps/36-blocks/src/app/panel/logs/log-details-side-dialog/log-details-side-dialog.component.ts
+++ b/apps/36-blocks/src/app/panel/logs/log-details-side-dialog/log-details-side-dialog.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, inject } from '@angular/core';
-import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
+import { AsyncPipe, JsonPipe, NgTemplateOutlet } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCardModule } from '@angular/material/card';
@@ -16,6 +16,7 @@ import { Observable } from 'rxjs';
     selector: 'proxy-log-details-side-dialog',
     imports: [
         AsyncPipe,
+        JsonPipe,
         NgTemplateOutlet,
         MatButtonModule,
         MatIconModule,
@@ -25,7 +26,6 @@ import { Observable } from 'rxjs';
         NoRecordFoundComponent,
     ],
     templateUrl: './log-details-side-dialog.component.html',
-    styleUrls: ['./log-details-side-dialog.component.scss'],
 })
 export class LogsDetailsSideDialogComponent extends BaseComponent implements OnDestroy {
     public dialogRef = inject<MatDialogRef<LogsDetailsSideDialogComponent>>(MatDialogRef);

--- a/apps/36-blocks/src/app/panel/logs/log/log.component.ts
+++ b/apps/36-blocks/src/app/panel/logs/log/log.component.ts
@@ -387,16 +387,18 @@ export class LogComponent extends BaseComponent implements OnDestroy, OnInit {
         if (!this.logDetailDialogRef) {
             const clientSettings: IClientSettings = this.getValueFromObservable(this.clientSettings$);
             this.logDetailDialogRef = this.dialog.open(LogsDetailsSideDialogComponent, {
-                panelClass: ['mat-right-dialog', 'mat-dialog-lg'],
+                panelClass: ['mat-right-dialog', 'mat-dialog-xlg'],
                 data: {
                     logData$: this.reqLogs$,
                     isLoading$: this.componentStore.reqLogsInProcess$,
                     logSettings: clientSettings?.client?.settings?.logs,
                 },
-                autoFocus: false,
-                hasBackdrop: false,
+                maxHeight: '100vh',
+                autoFocus: true,
+                hasBackdrop: true,
                 enterAnimationDuration: '0ms',
                 exitAnimationDuration: '0ms',
+                disableClose: false,
             });
             this.logDetailDialogRef.afterClosed().subscribe(() => {
                 this.componentStore.resetReqLog();

--- a/apps/36-blocks/src/styles.scss
+++ b/apps/36-blocks/src/styles.scss
@@ -113,6 +113,7 @@ button {
     box-shadow: -4px 0px 16px #00000059;
     &.mat-dialog-lg {
         width: 535px;
+        max-width: 535px !important;
         @media only screen and (max-width: 768px) {
             width: 100%;
             max-width: 100% !important;
@@ -120,14 +121,18 @@ button {
     }
     &.mat-dialog-md {
         width: 450px;
+        max-width: 450px !important;
     }
     &.mat-dialog-xs {
         width: 374px;
+        max-width: 374px !important;
     }
     &.mat-dialog-xlg {
         width: 40vw;
+        max-width: 40vw !important;
         @media only screen and (max-width: 1280px) {
             width: 60vw;
+            max-width: 60vw !important;
         }
         @media only screen and (max-width: 992px) {
             width: 100%;


### PR DESCRIPTION

- Update conditional logic to display headers, request body, and response sections when logSettings is null/undefined
- Change conditions from checking only store_* flags to also checking if logSettings exists
- Add MatCardModule and NoRecordFoundComponent imports to support enhanced UI display