### PR TITLE
Divyanshu | fix: add dark mode support to dashboard loading skeletons and correct overview data path

### DIFF
--- a/apps/36-blocks/src/app/panel/dashboard/breakdown-chart/breakdown-chart.component.html
+++ b/apps/36-blocks/src/app/panel/dashboard/breakdown-chart/breakdown-chart.component.html
@@ -18,7 +18,7 @@
     <!-- Loading Skeleton -->
     @if (isLoading()) {
         <div class="animate-pulse flex flex-col gap-3 mt-2">
-            <div class="h-48 rounded bg-gray-100"></div>
+            <div class="h-48 rounded bg-gray-100 dark:bg-gray-600"></div>
         </div>
     }
 

--- a/apps/36-blocks/src/app/panel/dashboard/dashboard.component.html
+++ b/apps/36-blocks/src/app/panel/dashboard/dashboard.component.html
@@ -55,9 +55,9 @@
         @if (isLoadingOverview()) {
             @for (i of [1, 2, 3, 4]; track i) {
                 <div class="rounded-2xl bg-color p-5 animate-pulse shadow-sm">
-                    <div class="h-3 w-24 rounded bg-gray-200 mb-4"></div>
-                    <div class="h-8 w-16 rounded bg-gray-200 mb-2"></div>
-                    <div class="h-3 w-28 rounded bg-gray-100"></div>
+                    <div class="h-3 w-24 rounded bg-gray-200 dark:bg-gray-700 mb-4"></div>
+                    <div class="h-8 w-16 rounded bg-gray-200 dark:bg-gray-700 mb-2"></div>
+                    <div class="h-3 w-28 rounded bg-gray-100 dark:bg-gray-600"></div>
                 </div>
             }
         } @else {

--- a/apps/36-blocks/src/app/panel/dashboard/dashboard.component.ts
+++ b/apps/36-blocks/src/app/panel/dashboard/dashboard.component.ts
@@ -132,7 +132,7 @@ export class DashboardComponent extends BaseComponent implements OnInit {
             .pipe(takeUntil(this.destroy$))
             .subscribe({
                 next: (res: any) => {
-                    this.overviewData.set(res?.data ?? null);
+                    this.overviewData.set(res?.data?.data ?? null);
                     this.isLoadingOverview.set(false);
                 },
                 error: (err: any) => {

--- a/apps/36-blocks/src/app/panel/dashboard/timeseries-chart/timeseries-chart.component.html
+++ b/apps/36-blocks/src/app/panel/dashboard/timeseries-chart/timeseries-chart.component.html
@@ -1,8 +1,8 @@
 <!-- Loading Skeleton -->
 @if (isLoading()) {
     <div class="animate-pulse flex flex-col gap-3">
-        <div class="h-4 w-1/3 rounded bg-gray-200"></div>
-        <div class="h-48 rounded bg-gray-100"></div>
+        <div class="h-4 w-1/3 rounded bg-gray-200 dark:bg-gray-700"></div>
+        <div class="h-48 rounded bg-gray-100 dark:bg-gray-600"></div>
     </div>
 }
 
@@ -17,12 +17,12 @@
 <!-- Charts: bare cards, parent grid controls layout -->
 @if (isLoading()) {
     <div class="rounded-2xl bg-color shadow-sm p-5 animate-pulse">
-        <div class="h-4 w-24 rounded bg-gray-200 mb-4"></div>
-        <div class="h-48 rounded bg-gray-100"></div>
+        <div class="h-4 w-24 rounded bg-gray-200 dark:bg-gray-700 mb-4"></div>
+        <div class="h-48 rounded bg-gray-100 dark:bg-gray-600"></div>
     </div>
     <div class="rounded-2xl bg-color shadow-sm p-5 animate-pulse">
-        <div class="h-4 w-24 rounded bg-gray-200 mb-4"></div>
-        <div class="h-48 rounded bg-gray-100"></div>
+        <div class="h-4 w-24 rounded bg-gray-200 dark:bg-gray-700 mb-4"></div>
+        <div class="h-48 rounded bg-gray-100 dark:bg-gray-600"></div>
     </div>
 }
 @if (!isLoading() && seriesList().length) {

--- a/apps/shared/scss/global.scss
+++ b/apps/shared/scss/global.scss
@@ -1,6 +1,8 @@
 @use 'tailwindcss';
 @use './imports';
 @use './mixins/common-utils' as *;
+
+@variant dark (&:where(.dark-theme, .dark-theme *));
 @source not inline("group-[aria-current=page]:text-indigo-600");
 .service-list {
     &.mat-mdc-list-base {


### PR DESCRIPTION

- Add dark mode variants (dark:bg-gray-600/700) to all skeleton loading states
- Fix overview data extraction path from res?.data to res?.data?.data
- Add Tailwind dark variant configuration for dark-theme class support